### PR TITLE
Small text fix in color examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -530,7 +530,7 @@
     <div class="row">
       <div class="small-12 medium-6 large-4 columns">
         <ul class="demo-colors">
-          <li class="brown darken-3 text-brown text-lighten-4 text-bold">Dark and light brown</li>
+          <li class="brown darken-3 text-brown text-lighten-4 text-bold">Dark and Light brown</li>
         </ul>
       </div>
       
@@ -542,7 +542,7 @@
       
       <div class="small-12 medium-6 large-4 columns">
         <ul class="demo-colors">
-          <li class="light-blue lighten-5 text-light-blue text-light-blue-darken-3 text-bold">Indigo and Pink</li>
+          <li class="light-blue lighten-5 text-light-blue text-light-blue-darken-3 text-bold">Light and Dark Blue</li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
Made a small mistake while copying one example to another. Fixed the text to match colors being used in each particular example.