### PR TITLE
Floating Label fix while invalid

### DIFF
--- a/scss/components/_text-fields.scss
+++ b/scss/components/_text-fields.scss
@@ -34,7 +34,7 @@ input[type="text"], input[type="password"], input[type="date"], input[type="date
     height: 0;
     cursor: text;
   }
-  &.with-floating-label:focus, &.with-floating-label:valid {
+  &.with-floating-label:focus, &.with-floating-label:valid, &.with-floating-label:invalid {
     & + label.floating-label {
       color: $primary-color;
       font-size: rem-calc(12);


### PR DESCRIPTION
Floating Label was rendering incorrect while the input is invalid by the type. For example the input type="email" was breaking apart the floating label, if the input is not a valid email.