### PR TITLE
invalid rendering further fix. :invalid:not(:empty) substitute

### DIFF
--- a/index.html
+++ b/index.html
@@ -627,6 +627,8 @@
       <input type="text" id="input_2" placeholder="Hint Text" />
       <input type="text" id="input_1" class="with-floating-label" required />
       <label for="input_1" class="floating-label">Floating Label Text</label>
+      <input type="email" id="input_3" placeholder=" " class="with-floating-label" required />
+      <label for="input_3" class="floating-label">Floating Label Text for Email</label>
     </div>
 
     <hr>

--- a/index.html
+++ b/index.html
@@ -625,7 +625,7 @@
 
     <div class="row column">
       <input type="text" id="input_2" placeholder="Hint Text" />
-      <input type="text" id="input_1" placeholder=" " class="with-floating-label" required />
+      <input type="text" id="input_1" class="with-floating-label" required />
       <label for="input_1" class="floating-label">Floating Label Text</label>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -625,7 +625,7 @@
 
     <div class="row column">
       <input type="text" id="input_2" placeholder="Hint Text" />
-      <input type="text" id="input_1" class="with-floating-label" required />
+      <input type="text" id="input_1" placeholder=" " class="with-floating-label" required />
       <label for="input_1" class="floating-label">Floating Label Text</label>
     </div>
 

--- a/scss/components/_text-fields.scss
+++ b/scss/components/_text-fields.scss
@@ -34,7 +34,7 @@ input[type="text"], input[type="password"], input[type="date"], input[type="date
     height: 0;
     cursor: text;
   }
-  &.with-floating-label:focus, &.with-floating-label:valid, &.with-floating-label:invalid {
+  &.with-floating-label:focus, &.with-floating-label:valid, &.with-floating-label:invalid:not(:placeholder-shown) {
     & + label.floating-label {
       color: $primary-color;
       font-size: rem-calc(12);

--- a/scss/components/_text-fields.scss
+++ b/scss/components/_text-fields.scss
@@ -34,7 +34,7 @@ input[type="text"], input[type="password"], input[type="date"], input[type="date
     height: 0;
     cursor: text;
   }
-  &.with-floating-label:focus, &.with-floating-label:valid, &.with-floating-label:invalid:not(:placeholder-shown) {
+  &.with-floating-label:focus, &.with-floating-label:valid {
     & + label.floating-label {
       color: $primary-color;
       font-size: rem-calc(12);

--- a/scss/components/_text-fields.scss
+++ b/scss/components/_text-fields.scss
@@ -34,7 +34,7 @@ input[type="text"], input[type="password"], input[type="date"], input[type="date
     height: 0;
     cursor: text;
   }
-  &.with-floating-label:focus, &.with-floating-label:valid {
+  &.with-floating-label:focus, &.with-floating-label:valid, &.with-floating-label:invalid:not(:placeholder-shown) {
     & + label.floating-label {
       color: $primary-color;
       font-size: rem-calc(12);


### PR DESCRIPTION
* Since the css does not cover :invalid:not(:empty) selector, same effect substituted by :invalid:not(:placeholder-shown) and a empty dummy input attribute (placeholder=" ")  which contains only a space. Floating Label was rendering incorrect while the input is invalid by the type. For example the input type="email" was breaking apart the floating label, if the input is not a valid email.